### PR TITLE
disable escaping of html entities in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "{{ name }}",
   "version": "1.0.0",
-  "description": "{{ description }}",
-  "author": "{{ author }}",
+  "description": "{{{ description }}}",
+  "author": "{{{ author }}}",
   "license": "ISC",
   "repository": "https://github.com/{{ owner }}/{{ repo }}.git",
   "scripts": {


### PR DESCRIPTION
e.g., the `author` field is often "First Last <email@address.com>".  `<` becomes `&lt;` and `>` becomes `&gt;` if escaping is enabled